### PR TITLE
space-dependent table newline tests

### DIFF
--- a/domador.js
+++ b/domador.js
@@ -295,6 +295,7 @@ Domador.prototype.parse = function parse () {
     }
   }
   this.append('');
+  this.buffer = this.buffer.replace(/\n{3,}/g, '\n\n')
   return this.buffer = trim(this.buffer);
 };
 
@@ -573,6 +574,7 @@ Domador.prototype.tables = function tables (el) {
 
   var name = el.tagName;
   if (name === 'TABLE') {
+    this.append('\n\n');
     this.tableCols = [];
     return;
   }

--- a/test/domador.js
+++ b/test/domador.js
@@ -177,6 +177,77 @@ test('tables are parsed into gfm tables by default', function (t) {
   t.end();
 });
 
+test('tables are parsed into gfm tables by default, after p, normally spaced', function (t) {
+  t.equal(domador(`
+    <p>Hi, there!</p>
+    <table>
+    <thead><tr>
+    <th>ones</th>
+    <th>twos</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+    <td>one</td>
+    <td>two</td>
+    </tr>
+    </tbody>
+    </table>`),
+`Hi, there!
+
+| ones | twos |
+|------|------|
+| one  | two  |`);
+  t.end();
+});
+
+test('tables are parsed into gfm tables by default, after p, without extra spaces', function (t) {
+  t.equal(domador(`
+    <p>Hi, there!</p>
+<table>
+<thead><tr>
+    <th>ones</th>
+    <th>twos</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+    <td>one</td>
+    <td>two</td>
+    </tr>
+    </tbody>
+    </table>`),
+`Hi, there!
+
+| ones | twos |
+|------|------|
+| one  | two  |`);
+  t.end();
+});
+
+test('tables are parsed into gfm tables separated from subsequent elements by only one newline', function (t) {
+  t.equal(domador(`<table>
+    <thead><tr>
+    <th>ones</th>
+    <th>twos</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+    <td>one</td>
+    <td>two</td>
+    </tr>
+    </tbody>
+    </table>
+<p>Hi, there!</p>`),
+`| ones | twos |
+|------|------|
+| one  | two  |
+
+Hi, there!`);
+  t.end();
+});
+
 test('tables with complex content still get proper padding', function (t) {
   t.equal(domador(`<table>
     <thead>
@@ -212,5 +283,13 @@ test('domador understands markers', function (t) {
   t.equal(domador('<strong>foo</strong>', { markers: [[6, '[START]'], [10, '[END]']] }), '**[START]fo[END]o**');
   t.equal(domador('<strong>foo</strong>', { markers: [[8, '[START]'], [10, '[END]']] }), '**[START]fo[END]o**');
   t.equal(domador('<code class="md-lang-js">foo</code>', { markers: [[8, '[START]'], [26, '[END]']] }), '`[START]f[END]oo`');
+  t.end();
+});
+
+test('domador converts double newlines into single newlines', function (t) {
+  t.equal(domador('<p>Hello</p>\n<p>Hello</p>'),       'Hello\n\nHello');
+  t.equal(domador('<p>Hello</p>\n\n<p>Hello</p>'),     'Hello\n\nHello');
+  t.equal(domador('<p>Hello</p>\n\n\n<p>Hello</p>'),   'Hello\n\nHello');
+  t.equal(domador('<p>Hello</p>\n\n\n\n<p>Hello</p>'), 'Hello\n\nHello');
   t.end();
 });


### PR DESCRIPTION
I found that tables after `p` or `ul` tags caused a missing newline, and produced invalid markdown that can't be converted to HTML:

https://github.com/bevacqua/domador/issues/1#issuecomment-218515293

I wrote a test to reproduce this -- it seems that the extra spaces in the test don't trigger this bug, but removing spaces causes it, so I made two tests to show it working and not working. 

If you can offer any tips on this bug I'm happy to try to fix it as well! Thanks!

The test failure shows:

``````
# tables are parsed into gfm tables by default, after p
not ok 32 should be equal
  ---
    operator: equal
    expected: 'Hi, there!\n| ones | twos |\n|------|------|\n| one  | two  |'
    actual:   'Hi, there!| ones | twos |\n|------|------|\n| one  | two  |'
    at: Test.<anonymous> (/home/warren/sites/domador/test/domador.js:181:5)
  ...
```` #
``````
